### PR TITLE
chg: [config] add conditional logging to stdout in config.cfg

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -12,6 +12,7 @@ sed -i "s#session_secret = \*\*Change_Me\*\*#session_secret = $(cat /dev/urandom
 sed -i "s#auth_enabled = False#auth_enabled = $AUTH_ENABLED#" config/config.cfg
 sed -i "s#ssl_verify = True#ssl_verify = $SSL_VERIFY#" config/config.cfg
 
+sed -i "s#stdout = False#stdout = True" config/config.cfg
 
 sed -i "s#\"url\": \"http://localhost\"#\"url\": \"$MISP_URL\"#" config/config.cfg
 sed -i "s#\"zmq\": \"tcp://localhost:50000\"#\"zmq\": \"tcp://$ZMQ_URL:$ZMQ_PORT\"#" config/config.cfg

--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,7 @@ sed -i "s#misp_web_url = http://0.0.0.0#misp_web_url=$MISP_URL#" config/config.c
 sed -i "s#auth_enabled = False#auth_enabled = True#" config/config.cfg
 sed -i "s#misp_fqdn = https://misp.local#misp_fqdn = https://$MISP_URL#" config/config.cfg
 sed -i "s#session_secret = **Change_Me**#session_secret = $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 64 | head -n 1)#" config/config.cfg
+sed -i "s#stdout = False#stdout = True#" config/config.cfg
 
 sed -i "s#\"url\": \"http://localhost\"#\"url\": \"$MISP_URL\"#" config/config.cfg
 sed -i "s#\"zmq\": \"tcp://localhost:50000\"#\"zmq\": \"tcp://$ZMQ_URL:$ZMQ_PORT\"#" config/config.cfg


### PR DESCRIPTION
The default is set `True` in misp-dashboard but we're checking for `stdout = False` as it's likely to be off by default upstream.